### PR TITLE
Support Docker installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env: 
-        REPO: nicofgrx/sparrow # TODO change before PR
+        REPO: fireflans/sparrow
 
     steps:
       - name: Set version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env: 
+        REPO: nicofgrx/sparrow # TODO change before PR
+
     steps:
       - name: Set version
         id: version
@@ -35,5 +38,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ github.repository }}:${{ steps.version.outputs.tag }}
-            ${{ github.repository }}:latest
+            ${{ env.REPO }}:${{ steps.version.outputs.tag }}
+            ${{ env.REPO }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Docker Build
+
+on:
+  push:
+    tags:
+        - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version
+        id: version
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: build
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ github.repository }}:${{ steps.version.outputs.tag }}
+            ${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Stage 1: Build stage
+FROM golang:1.23-alpine AS build
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o sparrow .
+
+# Stage 2: Final stage
+FROM scratch
+
+WORKDIR /app
+
+# Copy the builded app
+COPY --from=build /app/sparrow .
+
+COPY config /app/config
+COPY playground /app/playground
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/sparrow"]

--- a/README.md
+++ b/README.md
@@ -38,22 +38,17 @@ In addition it provides a security labels playground and an administration inter
    - To access API documentation, go to `http://localhost:8080/documentation/index.html`
 
 ### Running the Server with Docker
-1. **Build the Docker Image**:
-   ```bash
-   docker build . -t sparrow
-   ```
-2. **Run the Docker Container**:
-   ```bash
-   docker run -p 8080:8080 -d sparrow
-   ```
-3. **Pull the Docker Image from Docker Hub**:
-   ```bash
-   docker pull fireflans/sparrow:<version>
-   ```
-4. **Run the Docker Container from Docker Hub**:
-   ```bash
-   docker run -p 8080:8080 fireflans/sparrow:<version>
-   ```
+#### Build from source 
+```bash
+docker build . -t sparrow
+docker run -p 8080:8080 -d sparrow
+```
+
+#### Prebuild image
+```bash
+docker pull fireflans/sparrow:<version>
+docker run -p 8080:8080 fireflans/sparrow:<version>
+```
 
 ## Testing
 To run the tests, start the server and use the following command:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ In addition it provides a security labels playground and an administration inter
 2. **Access the API**:
    - The server runs on `http://localhost:8080`.
    - To access API documentation, go to `http://localhost:8080/documentation/index.html`
+
+### Running the Server with Docker
+1. **Build the Docker Image**:
+   ```bash
+   docker build . -t sparrow
+   ```
+2. **Run the Docker Container**:
+   ```bash
+   docker run -p 8080:8080 -d sparrow
+   ```
+3. **Pull the Docker Image from Docker Hub**:
+   ```bash
+   docker pull fireflans/sparrow:<version>
+   ```
+4. **Run the Docker Container from Docker Hub**:
+   ```bash
+   docker run -p 8080:8080 fireflans/sparrow:<version>
+   ```
+
 ## Testing
 To run the tests, start the server and use the following command:
 ```bash


### PR DESCRIPTION
Hi!

This PR adds a `Dockerfile` to build Sparrow and package it inside a container. This can be useful in container-based setups (e.g., Kubernetes) or air-gapped environments.

The `.github/workflows/release.yml` workflow is useful for publishing a Docker image based on GitHub tags/releases.

To build and push an image to DockerHub, use the following commands (you need to configure the secrets `DOCKER_USERNAME` and `DOCKER_PASSWORD` in your GitHub repository to push to your DockerHub repo):

```bash
git tag vx.x.x
git push --tags
```

On my fork, I tested with `nicofgrx/sparrow:v0.0.2`. You can use this image to test the container.